### PR TITLE
Add Merge Schedule action

### DIFF
--- a/.github/workflows/merge-schedule.yml
+++ b/.github/workflows/merge-schedule.yml
@@ -1,0 +1,24 @@
+name: Merge Schedule
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+  schedule:
+    # https://crontab.guru/every-hour
+    - cron: 0 * * * *
+
+jobs:
+  merge_schedule:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: gr2m/merge-schedule-action@v1
+        with:
+          # Merge method to use. Possible values are merge, squash or
+          # rebase. Default is merge.
+          merge_method: squash
+          #  Time zone to use. Default is UTC.
+          time_zone: "America/Sao_Paulo"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This will allow me to merge new questions exactly at midnight.
I need to do this because editing the questions CSV during the day would interfere with the shuffling algorithm and the questions would be different for that same day.