### PR TITLE
Add 'https://' to the share link

### DIFF
--- a/src/components/ScoreModal.vue
+++ b/src/components/ScoreModal.vue
@@ -74,7 +74,7 @@ export default {
 				.join("");
 		},
 		shareText() {
-			return `joguei geenio n°${this.gameNumber} ${this.totalCorrectAnswers}/${this.totalQuestions}\n\n${this.scoreCircles}\n\ngeenio.bandeira.dev`;
+			return `joguei geenio n°${this.gameNumber} ${this.totalCorrectAnswers}/${this.totalQuestions}\n\n${this.scoreCircles}\n\nhttps://geenio.bandeira.dev`;
 		},
 	},
 	beforeMount: function () {


### PR DESCRIPTION
Some apps don’t recognize geenio.bandeira.dev as a link, so changing it to https://geenio.bandeira.dev might give them a clue.